### PR TITLE
Remove redundant variable in spinner thread

### DIFF
--- a/spinner.h
+++ b/spinner.h
@@ -429,7 +429,6 @@ static void *spinner_thread(void *arg) {
     const char *msg = s->message ? s->message : "";
     pthread_mutex_unlock(&s->lock);
 
-    int term_width = spinner_term_width;
 
     for (int j = 0; j < s->indent; j++)
       fputc(' ', s->out);


### PR DESCRIPTION
## Summary
- remove unused `term_width` variable from `spinner_thread`

## Testing
- `gcc -std=c99 example.c -pthread -o example`

------
https://chatgpt.com/codex/tasks/task_e_68404be719348328af6a3c20a527d1d5