### PR TITLE
Fix race on spinner start

### DIFF
--- a/spinner.h
+++ b/spinner.h
@@ -530,11 +530,11 @@ static void spinner_start(Spinner *spinner) {
   if (!spinner->show_cursor)
     hide_cursor(spinner->out);
 
+  spinner->running = 1;
   pthread_create(&spinner->tid, NULL, spinner_thread, spinner);
   // pthread_detach(spinner->tid);
 
   spinner->message = spinner->message ? strdup(spinner->message) : NULL;
-  spinner->running = 1;
 }
 
 // ⏹️ Stop Spinner


### PR DESCRIPTION
## Summary
- start the spinner thread only after setting `running = 1`

## Testing
- `gcc -Wall -Wextra -pedantic example.c -o spinner_example`

------
https://chatgpt.com/codex/tasks/task_e_68404be5958c83288df5a539bb45a5d1