### PR TITLE
Update README compile instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ int main() {
 Compile with:
 
 ```bash
-gcc your_program.c -o your_program
+gcc your_program.c -o your_program -pthread
 ```
 
 ## Built-in Spinner Styles 🎨
@@ -150,7 +150,7 @@ The repository includes an example.c file that demonstrates the library:
 Compile and run it with:
 
 ```bash
-gcc example.c -o spinner
+gcc example.c -o spinner -pthread
 ./spinner
 ```
 


### PR DESCRIPTION
## Summary
- mention `-pthread` flag when compiling a program that uses `spinner.h`
- update the example build instructions

## Testing
- `gcc example.c -o spinner -pthread`
- `./spinner` *(fails: Terminated after manual interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68404be4697883289139534dcee51ae2