### PR TITLE
Add C++ extern guards

### DIFF
--- a/spinner.h
+++ b/spinner.h
@@ -567,6 +567,9 @@ static void spinner_stop(Spinner *spinner) {
 }
 
 // 🔍 Find Spinner
+#ifdef __cplusplus
+extern "C" {
+#endif
 const char *find_spinner_by_name(const char *name) {
   int count = sizeof(spinners) / sizeof(spinners[0]);
   for (int i = 0; i < count; i++) {
@@ -576,4 +579,7 @@ const char *find_spinner_by_name(const char *name) {
   }
   return NULL;
 }
+#ifdef __cplusplus
+}
+#endif
 #endif // SPINNER_H


### PR DESCRIPTION
## Summary
- ensure `find_spinner_by_name` has C linkage when used from C++

## Testing
- `gcc -std=c11 -Wall -Wextra -pedantic example.c -o example_c`
- `g++ -std=c++11 -Wall -Wextra -pedantic example.c -o example_cpp` *(fails: designator order does not match)*

------
https://chatgpt.com/codex/tasks/task_e_68404be6e7148328ba5820a1f33df25a