### PR TITLE
Fix ODR for spinner_registry_lock

### DIFF
--- a/spinner.h
+++ b/spinner.h
@@ -53,7 +53,7 @@ static void spinner_stop(Spinner *spinner);
 static volatile sig_atomic_t spinner_resize_requested = 0;
 static Spinner *active_spinners[MAX_ACTIVE_SPINNERS];
 static int active_spinner_count = 0;
-pthread_mutex_t spinner_registry_lock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t spinner_registry_lock = PTHREAD_MUTEX_INITIALIZER;
 
 // ⚙️⚙️ Spinners
 typedef struct {


### PR DESCRIPTION
## Summary
- mark `spinner_registry_lock` static to avoid multiple definitions

## Testing
- `gcc -Wall -Wextra -pedantic example.c -o spinner -pthread`

------
https://chatgpt.com/codex/tasks/task_e_6841ff4b46608328b618aa55f9550038