### PR TITLE
Update macro guards in spinner.h

### DIFF
--- a/spinner.h
+++ b/spinner.h
@@ -1,7 +1,11 @@
 // spinner.h - single drop-in header utf8 text spinner library
 
+#ifndef _XOPEN_SOURCE
 #define _XOPEN_SOURCE 700
+#endif
+#ifndef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 200809L
+#endif
 #define MAX_ACTIVE_SPINNERS 64
 
 #ifndef SPINNER_H


### PR DESCRIPTION
## Summary
- ensure `_XOPEN_SOURCE` and `_POSIX_C_SOURCE` are only defined when absent

## Testing
- `gcc example.c -o spinner_example -pthread`

------
https://chatgpt.com/codex/tasks/task_e_6841ff4a7c8083288152afbb2a1ba8b9