### PR TITLE
Fix locale initialization

### DIFF
--- a/spinner.h
+++ b/spinner.h
@@ -509,7 +509,8 @@ static void spinner_start(Spinner *spinner) {
   if (spinner->running) {
     return;
   }
-  setlocale(LC_ALL, "");
+  // Initialize locale for character classification
+  setlocale(LC_CTYPE, "");
   atexit(spinner_atexit_handler);
 
   pthread_mutex_init(&spinner->lock, NULL);


### PR DESCRIPTION
## Summary
- use LC_CTYPE for locale setup

## Testing
- `gcc example.c -o spinner -pthread`

------
https://chatgpt.com/codex/tasks/task_e_6841ff478f4883289086ed69651978c2